### PR TITLE
fix profile ID locator

### DIFF
--- a/give_kudos.py
+++ b/give_kudos.py
@@ -65,9 +65,10 @@ class KudosGiver:
             self.page.keyboard.press('PageUp')
 
         try:
-            self.own_profile_id = self.page.locator("#athlete-profile .card-body > a").get_attribute('href').split("/athletes/")[1]
+            self.own_profile_id = self.page.locator(".user-menu > a").get_attribute('href').split("/athletes/")[1]
+            print("id", self.own_profile_id)
         except:
-            self.own_profile_id = '17796761'  ## your own athlete id.
+            print("can't find own profile ID")
 
     def locate_kudos_buttons_and_maybe_give_kudos(self, web_feed_entry_locator) -> int:
         """


### PR DESCRIPTION
updates the profile ID locator function to extract the profile ID from the page. It looks like Strava updated their website and the previously used element was removed.

Also, instead of hardcoding own profile ID, the function will just inform the user that the profile ID was not found.