### PR TITLE
Reduce GH action run duration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build Image
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/README.md'
+      - '**/LICENSE'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ env.OWNER_LC }}/strava-kudos:latest

--- a/.github/workflows/give_kudos.yml
+++ b/.github/workflows/give_kudos.yml
@@ -2,23 +2,20 @@ name: Give Strava Kudos
 
 on:
   schedule:
-    - cron: "30 5-23/6 * * *"
+    - cron: "30 6 */3 * *"
   workflow_dispatch:
 
-env:
-  STRAVA_EMAIL: ${{ secrets.STRAVA_EMAIL }}
-  STRAVA_PASSWORD: ${{ secrets.STRAVA_PASSWORD }}
 jobs:
   run-kudos-cron:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9.10'
-          cache: 'pip'
-      - run: pip install -r requirements.txt
-      - run: playwright install
-      - run: python give_kudos.py
-        
+      - name: set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
+      - name: run container
+        run: |
+          docker run --cpus 1 -e STRAVA_EMAIL=${{ secrets.STRAVA_EMAIL }} -e STRAVA_PASSWORD=${{ secrets.STRAVA_PASSWORD }} ghcr.io/${{ env.OWNER_LC }}/strava-kudos:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/playwright/python:v1.43.0-jammy
+
+ENV STRAVA_EMAIL=
+ENV STRAVA_PASSWORD=
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install -r requirements.txt
+
+CMD ["python", "give_kudos.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Strava Kudos Giver 👍👍👍
 
-[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-370/) ![Build](https://github.com/MaksimMisin/strava-kudos/actions/workflows/build.yml/badge.svg) ![Build](https://github.com/MaksimMisin/strava-kudos/actions/workflows/give_kudos.yml/badge.svg)
+[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-370/) ![Build](https://github.com/MaksimMisin/strava-kudos/actions/workflows/build.yml/badge.svg) [![Give Strava Kudos](https://github.com/MaksimMisin/strava-kudos/actions/workflows/give_kudos.yml/badge.svg)](https://github.com/MaksimMisin/strava-kudos/actions/workflows/give_kudos.yml)
 
 A Python tool to automatically give [Strava](https://www.strava.com) Kudos to recent activities on your feed. There are a few repos that uses JavaScript like [strava-kudos-lambda](https://github.com/mjad-org/strava-kudos-lambda) and [strava-kudos](https://github.com/rnvo/strava-kudos).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Strava Kudos Giver 👍👍👍
 
-[![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/downloads/release/python-370/) ![Github Actions](https://github.com/isaac-chung/strava-kudos/actions/workflows/give_kudos.yml/badge.svg)
+[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-370/) ![Build](https://github.com/MaksimMisin/strava-kudos/actions/workflows/build.yml/badge.svg) ![Build](https://github.com/MaksimMisin/strava-kudos/actions/workflows/give_kudos.yml/badge.svg)
 
-A Python tool to automatically give [Strava](https://www.strava.com) Kudos to recent activities on your feed. There are a few repos that uses JavaScript like [strava-kudos-lambda](https://github.com/mjad-org/strava-kudos-lambda) and [strava-kudos](https://github.com/rnvo/strava-kudos). 
+A Python tool to automatically give [Strava](https://www.strava.com) Kudos to recent activities on your feed. There are a few repos that uses JavaScript like [strava-kudos-lambda](https://github.com/mjad-org/strava-kudos-lambda) and [strava-kudos](https://github.com/rnvo/strava-kudos).
 
 The repo is set up so that the script runs on a set schedule via Github Actions. Github suggests in their [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) to not run cron jobs at the start of every hour to avoid delays so minute30 was chosen here. Feel free to change it to whenever you want. There is also a `max_run_duration` parameter which is 9 minutes by default so that we don't exceed the [monthly Github Action free tier minutes](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes) when the action is triggered a few times a day.
 
@@ -19,7 +19,7 @@ python3 give_kudos.py
 ## 🛠️Setup
 
 ### Playwright
-[Playwright](https://github.com/microsoft/playwright-python) is used, so be sure to follow instructions to install it properly. 
+[Playwright](https://github.com/microsoft/playwright-python) is used, so be sure to follow instructions to install it properly.
 
 ### Environment Variables
 
@@ -33,7 +33,7 @@ export STRAVA_PASSWORD=YOUR_PASSWORD
 To add secrets for GH actions, navigate to Settings -> Security -> Secrets and Variables -> Actions. Enter your email and password within `Repository Secrets`.
 
 ## 🔬Testing
-Manual testing was done in Python 3.9.10 on Ubuntu 20.04.6. 
+Manual testing was done in Python 3.9.10 on Ubuntu 20.04.6.
 
 ## Contributions
 Let me know if you wish to add anything or if there are any issues!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-playwright==1.30.0
+playwright==1.43.0


### PR DESCRIPTION
Playwright is a pretty heavy dependency and it felt wasteful to rebuild it in each cronjob.

I separated the building process into its own action and now execute the cron job from a pre-built container.

Update README.md badges if you decide to merge it.