### PR TITLE
Fix Handling of Password: Escaping Special Characters in STRAVA_PASSWORD

### DIFF
--- a/.github/workflows/give_kudos.yml
+++ b/.github/workflows/give_kudos.yml
@@ -18,4 +18,4 @@ jobs:
 
       - name: run container
         run: |
-          docker run --cpus 1 -e STRAVA_EMAIL=${{ secrets.STRAVA_EMAIL }} -e STRAVA_PASSWORD=${{ secrets.STRAVA_PASSWORD }} ghcr.io/${{ env.OWNER_LC }}/strava-kudos:latest
+          docker run --cpus 1 -e STRAVA_EMAIL=${{ secrets.STRAVA_EMAIL }} -e STRAVA_PASSWORD="'${{ secrets.STRAVA_PASSWORD }}'" ghcr.io/${{ env.OWNER_LC }}/strava-kudos:latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to handle passwords with special characters correctly by wrapping the password in single quotes:
`STRAVA_PASSWORD="'${{ secrets.STRAVA_PASSWORD }}'"
`
This ensures the shell does not misinterpret special characters in the password.